### PR TITLE
Refactor: Update install.conf.yaml with latest tools and fixes

### DIFF
--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -31,11 +31,13 @@
     - weaveworks/tap
 
 - brew:
+    - bottom
     - coreutils
     - docker
     - docker-buildx
     - docker-compose
     - fluxcd/tap/flux
+    - gh
     - git-delta
     - git-flow
     - go
@@ -48,6 +50,7 @@
     - jq
     - kubectl
     - kustomize
+    - lazygit
     - lolcat
     - neovim
     - node
@@ -70,7 +73,6 @@
     - appcleaner
     - balenaetcher
     - dbeaver-community
-    - hot
     - openlens
     - orbstack
     - qlmarkdown
@@ -84,7 +86,7 @@
       stdout: True,
       description: Nerd Fonts for your IDE
 
-    - command: "if [ -d '~/.config/nvim' ]; then git clone https://github.com/NvChad/starter ~/.config/nvim && nvim; fi"
+    - command: "if [ ! -d \"$HOME/.config/nvim\" ]; then git clone https://github.com/NvChad/starter \"$HOME/.config/nvim\"; else echo \"NvChad already installed at ~/.config/nvim. Skipping installation.\"; fi"
       stderr: True,
       stdout: True,
       description: Installing NvChad


### PR DESCRIPTION
This commit updates the brew and cask configurations in install.conf.yaml and refines some shell commands for better behavior.

Key changes:
- Removed duplicate 'hot' package from the cask list.
- Added 'gh', 'lazygit', and 'bottom' to the brew packages.
- Modified the NvChad installation command to:
    - Only install if the ~/.config/nvim directory does not already exist.
    - Prevent Neovim from automatically launching after cloning.
    - Provide a message if NvChad is already installed.

These changes aim to keep the toolset up-to-date and improve the robustness of the installation script.

## Summary by Sourcery

Update install.conf.yaml to refresh brew and cask package lists and enhance the NvChad installation logic

Bug Fixes:
- Remove duplicate 'hot' entry from cask list

Enhancements:
- Add 'gh', 'lazygit', and 'bottom' to the brew packages
- Make NvChad installation idempotent by checking for existing config, preventing auto-launch, and emitting a skip message